### PR TITLE
Added a note on the end_callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,27 @@ Vue Customized template
 **end_callback** - Event ended callback
 - `type`: Function
 - `required` : false
+
+If the `end-time` prop is dynamically generated or 'computed', the initial value will be `NaN`. This will trigger the `end_callback` function, which might not be desirable. This can be solved by declaring it this way:
+
+`
+<template>
+  <vue-countdown-timer
+    ...
+    :end-time="end_at?end_at:endAt"
+    ...
+    ></vue-countdown-timer>
+</template>
+<script>
+  data() {
+      return {
+          endAt:  (new Date).getTime()+5000
+      }
+  },
+</script>
+        
+`
+Where `end_at` is the computed value, and `endAt` is a default value.
     
 # Liscense
 MIT License


### PR DESCRIPTION
If the `end-time` value is dynamically generated or 'computed', the initial value will be `NaN`. This will trigger the `end_callback` function, which might not be desirable. This can be solved by setting a default value for the end-time prop